### PR TITLE
Removed leading tabs in definition of debug_classes for clean yml file.

### DIFF
--- a/vars/lvm_config_2.02.111.yml
+++ b/vars/lvm_config_2.02.111.yml
@@ -431,7 +431,7 @@ lvm__config_base:
     #   locking
     # Use "all" to see everything.
     debug_classes: [ "memory", "devices", "activation", "allocation",
-		      "lvmetad", "metadata", "cache", "locking" ]
+                     "lvmetad", "metadata", "cache", "locking" ]
 
 
   # Configuration of metadata backups and archiving.  In LVM2 when we


### PR DESCRIPTION
The leading tabs in line 434 led to an error during execution of the role. Replacing the tabs with spaces cures the problem and gives a valid YAML file (checked with this [website](http://www.yamllint.com)).