### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 - Updated documentation (hyphens supported in volume group name and resize
   filesystem). [tallandtree]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 v0.1.5
 ------
 
@@ -66,4 +68,3 @@ v0.1.0
 *Released: 2015-07-16*
 
 - Initial release. [drybjed]
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changelog
 - Updated documentation (hyphens supported in volume group name and resize
   filesystem). [tallandtree]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 v0.1.5
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ Changelog
 - Updated documentation (hyphens supported in volume group name and resize
   filesystem). [tallandtree]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 v0.1.5
 ------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Configure Logical Volume Manager (LVM)'
   company: 'DebOps'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.8.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   shell: dpkg-query -W -f='${Version}\n' 'lvm2' | grep -v '^$' | cut -d- -f1
   register: lvm__register_version
   changed_when: False
-  check_mode: no
+  check_mode: False
 
 - name: Lookup base LVM configuration
   include_vars: '{{ item }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   shell: dpkg-query -W -f='${Version}\n' 'lvm2' | grep -v '^$' | cut -d- -f1
   register: lvm__register_version
   changed_when: False
-  always_run: True
+  check_mode: no
 
 - name: Lookup base LVM configuration
   include_vars: '{{ item }}'


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.